### PR TITLE
Fix premature loading of sd_model upon WebUI launch

### DIFF
--- a/scripts/vram_estimator.py
+++ b/scripts/vram_estimator.py
@@ -18,25 +18,6 @@ import gradio as gr
 import pandas as pd
 
 
-DEFAULT_ARGS = {
-    'sd_model': shared.sd_model,
-    'prompt': 'postapocalyptic steampunk city, exploration, cinematic, realistic, hyper detailed, photorealistic maximum detail, volumetric light, (((focus))), wide-angle, (((brightly lit))), (((vegetation))), lightning, vines, destruction, devastation, wartorn, ruins',
-    'sampler_name': 'Euler a',
-    'batch_size': 1,
-    'n_iter': 1,
-    'steps': 1,
-    'cfg_scale': 15.0,
-    'width': 512,
-    'height': 512,
-    'restore_faces': False,
-    'tiling': False,
-    'do_not_save_samples': True,
-    'do_not_save_grid': True,
-    'negative_prompt': '(((blurry))), ((foggy)), (((dark))), ((monochrome)), sun, (((depth of field)))',
-    'do_not_reload_embeddings': True
-}
-
-
 curves = {}
 stats_file = os.path.join(scripts.basedir(), "stats.json")
 
@@ -115,6 +96,23 @@ def get_memory_stats():
 
 def run_benchmark(max_width, max_batch_count):
     global curves
+    DEFAULT_ARGS = {
+        'sd_model': shared.sd_model,
+        'prompt': 'postapocalyptic steampunk city, exploration, cinematic, realistic, hyper detailed, photorealistic maximum detail, volumetric light, (((focus))), wide-angle, (((brightly lit))), (((vegetation))), lightning, vines, destruction, devastation, wartorn, ruins',
+        'sampler_name': 'Euler a',
+        'batch_size': 1,
+        'n_iter': 1,
+        'steps': 1,
+        'cfg_scale': 15.0,
+        'width': 512,
+        'height': 512,
+        'restore_faces': False,
+        'tiling': False,
+        'do_not_save_samples': True,
+        'do_not_save_grid': True,
+        'negative_prompt': '(((blurry))), ((foggy)), (((dark))), ((monochrome)), sun, (((depth of field)))',
+        'do_not_reload_embeddings': True
+    }
     results = {}
 
     print("[VRAMEstimator] Starting benchmark...")


### PR DESCRIPTION
On current commit of A1111's WebUI (and for the last three weeks,) the extension causes sd_models to be called up before the vae_list is filled, causing the VAE to not load upon WebUI launch.

[Detailed here. (link)](https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/10355#issuecomment-1575404509)

While I pondered on editing the code on the AUTOMATIC1111's repo to work around the issue (i.e. fill the vae_list before extension loads), not many extensions load the model upon launch. *[citation needed]*

I thought the fix in this case could be to simply move the `DEFAULT_ARGS` to the `run_benchmark` function instead, since the arguments are expected to be seldom called upon during normal usage of the extension.